### PR TITLE
Spin out mainLayout.pug from baseLayout.pug 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bower_components
 *.sqlite3
 /venv
 *.tmp
+*.DS_Store
 
 # Project
 /static_collected

--- a/webapp/_pug/baseLayout.pug
+++ b/webapp/_pug/baseLayout.pug
@@ -1,5 +1,3 @@
-include mixins/navbar.pug
-
 block vars
     -
         var pageName = ""
@@ -17,32 +15,12 @@ html
             link(rel="stylesheet" type="text/css" href="/static/bower_components/font-awesome/css/font-awesome.min.css")
             link(rel="stylesheet" type="text/css" href="/static/bower_components/bootstrap/dist/css/bootstrap.min.css")
 
-            if DataTables
-                link(rel="stylesheet" type="text/css" href=locals.cdn.dataTables.css)
-
-
-            link(rel="stylesheet" type="text/css" href="/static/css/main.css")
-
     body
 
         include ./includes/googleAnalytics.html
-        include ./includes/mlh-season-badge.pug
 
         block body-container
-            #page-container
-                #header-container
-                    #header.container
-                        block navbar
-                            +navbar(navLinks.standard)
-                #content-container
-                    block page
-                        #content.container
-                            block content
-                                h1 TODO
-                #footer-container
-                    #footer.container
-                        include ./includes/footer.pug
-
+            
         //- JavaScript
         block scripts
             script(src="/static/bower_components/jquery/dist/jquery.min.js")
@@ -57,4 +35,3 @@ html
             script(src="/static/js/plugins/ajaxForm.js")
             script(src="/static/js/plugins/ajaxGet.js")
             script(src="/static/js/plugins/parallaxIt.js")
-            script(src="/static/js/main.js")

--- a/webapp/_pug/baseLayout.pug
+++ b/webapp/_pug/baseLayout.pug
@@ -19,7 +19,7 @@ html
 
         include ./includes/googleAnalytics.html
 
-        block body-container
+        block page
             
         //- JavaScript
         block scripts

--- a/webapp/_pug/mainLayout.pug
+++ b/webapp/_pug/mainLayout.pug
@@ -1,0 +1,27 @@
+extends ./baseLayout.pug
+
+include mixins/navbar.pug
+
+block append styles    
+    if DataTables
+        link(rel="stylesheet" type="text/css" href=locals.cdn.dataTables.css)
+    link(rel="stylesheet" type="text/css" href="/static/css/main.css")
+
+block body-container
+    include ./includes/mlh-season-badge.pug
+    #page-container
+        #header-container
+            #header.container
+                block navbar
+                    +navbar(navLinks.standard)
+        #content-container
+            block page
+                #content.container
+                    block content
+                        h1 TODO
+        #footer-container
+            #footer.container
+                include ./includes/footer.pug
+
+block append scripts
+    script(src="/static/js/main.js")

--- a/webapp/_pug/mainLayout.pug
+++ b/webapp/_pug/mainLayout.pug
@@ -7,7 +7,7 @@ block append styles
         link(rel="stylesheet" type="text/css" href=locals.cdn.dataTables.css)
     link(rel="stylesheet" type="text/css" href="/static/css/main.css")
 
-block body-container
+block page
     include ./includes/mlh-season-badge.pug
     #page-container
         #header-container

--- a/webapp/_pug/standardLayout.pug
+++ b/webapp/_pug/standardLayout.pug
@@ -1,4 +1,4 @@
-extends ./baseLayout.pug
+extends ./mainLayout.pug
 
 block navbar
     +navbar(navLinks.standard)

--- a/webapp/_pug/userLayout.pug
+++ b/webapp/_pug/userLayout.pug
@@ -1,4 +1,4 @@
-extends ./baseLayout.pug
+extends ./mainLayout.pug
 
 block navbar
     +navbar(navLinks.user)

--- a/webapp/views/hype/_hypeLayout.pug
+++ b/webapp/views/hype/_hypeLayout.pug
@@ -1,4 +1,4 @@
-extends ../../_pug/baseLayout.pug
+extends ../../_pug/mainLayout.pug
 
 block append styles
     link(rel="stylesheet" type="text/css" href="/static/views/hype/style.css")

--- a/webapp/views/hype/_hypeLayout.pug
+++ b/webapp/views/hype/_hypeLayout.pug
@@ -6,7 +6,7 @@ block append styles
 block append scripts
     script(src="/static/views/hype/script.js")
 
-block body-container
+block page
     .hype-content-container
         .hype-logo
             .hype-logo-line

--- a/webapp/views/index/index.pug
+++ b/webapp/views/index/index.pug
@@ -1,4 +1,4 @@
-extends ../../_pug/baseLayout.pug
+extends ../../_pug/mainLayout.pug
 
 mixin sponsorLogoTier(sponsorsList, tier)
     div(class=`sponsor-tier sponsor-tier-${tier}`)


### PR DESCRIPTION
This removes the structure of the main page (navigation/content/footer) from the baseLayout, so pages that don't rely on that structure (e.g. preview page) don't have it. 

Also includes ignoring .DS_Store files (albeit accidentally). 